### PR TITLE
Update React plugin embedding section

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -96,6 +96,9 @@ createPlugin(document.getElementById('app')!); // app is a <div> element
 
 To use the plugin (with the React UI) inside another React app:
 
+A single-plugin setup is shown the example below. In order to initialize multiple
+plugins, each with its own context and viewport, some extra steps are required (docs section to be added).
+
 ```ts
 import { useEffect, createRef } from "react";
 import { createPluginUI } from "molstar/lib/mol-plugin-ui";

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -105,7 +105,7 @@ import "molstar/lib/mol-plugin-ui/skin/light.scss";
 
 declare global {
   interface Window {
-    molstar?: PluginUIContext | undefined;
+    molstar?: PluginUIContext;
   }
 }
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -100,7 +100,8 @@ To use the plugin (with the React UI) inside another React app:
 import { useEffect, createRef } from "react";
 import { createPluginUI } from "molstar/lib/mol-plugin-ui";
 import { PluginUIContext } from "molstar/lib/mol-plugin-ui/context";
-import "molstar/build/viewer/molstar.css";
+/* Requires sass package, "npm install sass" or "yarn add sass" */
+import "molstar/lib/mol-plugin-ui/skin/light.scss";
 
 declare global {
   interface Window {

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -4,7 +4,7 @@ There are 4 basic ways of instantiating the Mol* plugin.
 
 ## ``Viewer`` wrapper
 
-- The most basic usage is to use the ``Viewer`` wrapper.This is best suited for use cases that do not require much custom behavior and are mostly about just displaying a structure.
+- The most basic usage is to use the ``Viewer`` wrapper. This is best suited for use cases that do not require much custom behavior and are mostly about just displaying a structure.
 - See ``Viewer`` class is defined in [src/apps/viewer/app.ts](https://github.com/molstar/molstar/blob/master/src/apps/viewer/app.ts) for available methods and options.
 
 Example usage without using WebPack:

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -104,20 +104,19 @@ import "molstar/build/viewer/molstar.css";
 
 declare global {
   interface Window {
-    molstar: PluginUIContext;
+    molstar?: PluginUIContext | undefined;
   }
 }
 
-window.molstar = window.molstar || {};
+window.molstar = window.molstar || undefined;
 
 export function MolStarWrapper() {
   const parent = createRef<HTMLDivElement>();
 
   useEffect(() => {
     async function init() {
-      window.molstar = await createPluginUI(parent.current as HTMLDivElement);
+        window.molstar = await createPluginUI(parent.current as HTMLDivElement);
 
-      if (window.molstar) {
         const data = await window.molstar.builders.data.download(
           { url: "https://files.rcsb.org/download/3PTB.pdb" }, /* replace with your URL */
           { state: { isGhost: true } }
@@ -128,11 +127,11 @@ export function MolStarWrapper() {
           trajectory,
           "default"
         );
-      }
     }
     init();
     return () => {
       window.molstar?.dispose();
+      window.molstar = undefined;
     };
   }, []);
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -100,7 +100,9 @@ To use the plugin (with the React UI) inside another React app:
 import { useEffect, createRef } from "react";
 import { createPluginUI } from "molstar/lib/mol-plugin-ui";
 import { PluginUIContext } from "molstar/lib/mol-plugin-ui/context";
-/* Requires sass package, "npm install sass" or "yarn add sass" */
+/*  Might require extra configuration,
+see https://webpack.js.org/loaders/sass-loader/ for example.
+create-react-app should support this natively. */
 import "molstar/lib/mol-plugin-ui/skin/light.scss";
 
 declare global {

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -109,7 +109,6 @@ declare global {
   }
 }
 
-window.molstar = window.molstar || undefined;
 
 export function MolStarWrapper() {
   const parent = createRef<HTMLDivElement>();


### PR DESCRIPTION
The current example for embedding the viewer in another React app was out of date.
I have added the necessary imports and also assigned the created plugin to `window.molstar`
so that it can be re-used across different files.